### PR TITLE
Enable CONFIG_IP_VS_NFCT in 4.10.8-docker

### DIFF
--- a/x86_64/4.10.8-docker/.config
+++ b/x86_64/4.10.8-docker/.config
@@ -1028,7 +1028,7 @@ CONFIG_IP_VS_SH_TAB_BITS=8
 # IPVS application helper
 #
 # CONFIG_IP_VS_FTP is not set
-# CONFIG_IP_VS_NFCT is not set
+CONFIG_IP_VS_NFCT=y
 
 #
 # IP: Netfilter Configuration


### PR DESCRIPTION
Hi,

This module is enable on docker kernel for armv7 and aarch64, but not on x86-64.

Thanks,